### PR TITLE
Add region persistence and rest resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 1.0.0 (under development)
 This is the initial version setting up the base system
 
+- `NEW` Add region code to message and ability to find messages by region code
+- `NEW` Add region resource to find regions by region code or location
+- `NEW` Add REST method to return a region hierachy by ars or location
+- `NEW` Basic region model
 - 'CNG' Change to Java 11
 - `NEW` Add Message resource to find a message by its identifier 
 - `CNG` Resource path 'api/message' is now 'api/messages'

--- a/src/main/java/de/dealog/msg/converter/UnsupportedConversionException.java
+++ b/src/main/java/de/dealog/msg/converter/UnsupportedConversionException.java
@@ -1,0 +1,9 @@
+package de.dealog.msg.converter;
+
+public class UnsupportedConversionException extends RuntimeException {
+
+    public UnsupportedConversionException(final String msg) {
+        super(msg);
+    }
+
+}

--- a/src/main/java/de/dealog/msg/event/UnsupportedGeometryException.java
+++ b/src/main/java/de/dealog/msg/event/UnsupportedGeometryException.java
@@ -1,33 +1,8 @@
-/*
- * This file is part of the GeoLatte project.
- *
- *     GeoLatte is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU Lesser General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     GeoLatte is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU Lesser General Public License for more details.
- *
- *     You should have received a copy of the GNU Lesser General Public License
- *     along with GeoLatte.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright (C) 2010 - 2012 and Ownership of code is shared by:
- * Qmino bvba - Romeinsestraat 18 - 3001 Heverlee  (http://www.qmino.com)
- * Geovise bvba - Generaal Eisenhowerlei 9 - 2140 Antwerpen (http://www.geovise.com)
- */
-
 package de.dealog.msg.event;
 
-/**
- * An exception for unsupported geometries.
- *
- */
 public class UnsupportedGeometryException extends RuntimeException {
 
-    public UnsupportedGeometryException(String msg) {
+    public UnsupportedGeometryException(final String msg) {
         super(msg);
     }
 

--- a/src/main/java/de/dealog/msg/persistence/model/GeocodeEntity.java
+++ b/src/main/java/de/dealog/msg/persistence/model/GeocodeEntity.java
@@ -13,10 +13,13 @@ import java.util.List;
 @Getter
 @Setter
 @Builder
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class GeocodeEntity extends PanacheEntity implements Geocode {
 
+    /**
+     * MD5 hash of the WKT String representation of the {@link GeocodeEntity#polygons}
+     */
     private String hash;
 
     /**

--- a/src/main/java/de/dealog/msg/persistence/model/Message.java
+++ b/src/main/java/de/dealog/msg/persistence/model/Message.java
@@ -12,6 +12,8 @@ public interface Message {
 
     Geocode getGeocode();
 
+    String getRegionCode();
+
     MessageStatus getStatus();
 
     Date getPublishedAt();

--- a/src/main/java/de/dealog/msg/persistence/model/MessageEntity.java
+++ b/src/main/java/de/dealog/msg/persistence/model/MessageEntity.java
@@ -9,7 +9,6 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
 import java.util.Date;
 
 @Entity
@@ -31,10 +30,12 @@ public class MessageEntity extends PanacheEntity implements Message {
     private String description;
 
     @ToString.Exclude
-    @NotNull
     @ManyToOne(optional = false, fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "geocode_id")
     private GeocodeEntity geocode;
+
+    @Column(columnDefinition="TEXT")
+    private String regionCode;
 
     @Enumerated(EnumType.STRING)
     private MessageStatus status;

--- a/src/main/java/de/dealog/msg/persistence/model/Region.java
+++ b/src/main/java/de/dealog/msg/persistence/model/Region.java
@@ -1,0 +1,9 @@
+package de.dealog.msg.persistence.model;
+
+public interface Region {
+    String getCode();
+
+    String getName();
+
+    String getDescription();
+}

--- a/src/main/java/de/dealog/msg/persistence/model/RegionEntity.java
+++ b/src/main/java/de/dealog/msg/persistence/model/RegionEntity.java
@@ -1,0 +1,51 @@
+package de.dealog.msg.persistence.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.MultiPolygon;
+import org.hibernate.annotations.Immutable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@Getter
+@Setter
+@Immutable
+@Table(name = "vg250_compound")
+public class RegionEntity extends PanacheEntity implements Region {
+
+    /**
+     * Amtlicher Regionalschlüssel
+     * 1.–2. Stelle   = Kennzahl des Bundeslandes
+     * 3. Stelle      = Kennzahl des Regierungsbezirks; wenn nicht vorhanden: 0
+     * 4.–5. Stelle   = Kennzahl des Landkreises oder der kreisfreien Stadt
+     * 6.–9. Stelle   = Verbandsschlüssel
+     * 10.–12. Stelle = Gemeindekennzahl
+     */
+    @Column(name = "ars")
+    private String code;
+
+    /**
+     * The name of the region
+     */
+    @Column(name = "gen")
+    private String name;
+
+    /**
+     * Description of the region
+     */
+    @Column(name = "bez")
+    private String description;
+
+    /**
+     * The geographic code delineating the affected area of the alert message
+     */
+    @ToString.Exclude
+    @Column(name = "geom")
+    private MultiPolygon<G2D> geometries;
+}

--- a/src/main/java/de/dealog/msg/persistence/repository/MessageRepository.java
+++ b/src/main/java/de/dealog/msg/persistence/repository/MessageRepository.java
@@ -6,9 +6,6 @@ import io.quarkus.hibernate.orm.panache.PanacheRepository;
 
 import javax.enterprise.context.ApplicationScoped;
 
-/**
- * Implementation of a {@link MessageEntity} repository
- */
 @ApplicationScoped
 public class MessageRepository implements PanacheRepository<MessageEntity> {
 

--- a/src/main/java/de/dealog/msg/persistence/repository/RegionRepository.java
+++ b/src/main/java/de/dealog/msg/persistence/repository/RegionRepository.java
@@ -1,0 +1,14 @@
+package de.dealog.msg.persistence.repository;
+
+import de.dealog.msg.persistence.model.RegionEntity;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class RegionRepository implements PanacheRepository<RegionEntity> {
+
+    public RegionEntity findByArs(final String ars){
+        return find("ars", ars).firstResult();
+    }
+}

--- a/src/main/java/de/dealog/msg/rest/ApiResource.java
+++ b/src/main/java/de/dealog/msg/rest/ApiResource.java
@@ -27,14 +27,14 @@ public class ApiResource {
     Optional<List<String>> mayBeVersions;
 
     /**
-     * Request the supported status of a ....
-     * @param version API version and ...
-     * @return if the version is supported it returns {@link javax.ws.rs.core.Response.Status#NOT_FOUND},
-*              else it return {@link javax.ws.rs.core.Response.Status#NO_CONTENT}
+     * Request the support status of a version string.
+     *
+     * @param version the API version as string
+     * @return if supported {@link javax.ws.rs.core.Response.Status#NOT_FOUND}
+*              else {@link javax.ws.rs.core.Response.Status#NO_CONTENT}
      */
     @GET
     public Response unsupported(@NotEmpty @QueryParam(QUERY_PARAM_VERSION) final String version) {
-
         Response response = Response.status(Response.Status.NOT_FOUND).build();
 
         if (mayBeVersions.isPresent() && mayBeVersions.get().contains(version)) {

--- a/src/main/java/de/dealog/msg/rest/MessageConverter.java
+++ b/src/main/java/de/dealog/msg/rest/MessageConverter.java
@@ -16,6 +16,7 @@ public class MessageConverter extends Converter<Message, MessageRest> {
         messageRest.setIdentifier(message.getIdentifier());
         messageRest.setHeadline(message.getHeadline());
         messageRest.setDescription(message.getDescription());
+        messageRest.setArs(message.getRegionCode());
         messageRest.setPublishedAt(message.getPublishedAt());
         return messageRest;
     }
@@ -26,6 +27,7 @@ public class MessageConverter extends Converter<Message, MessageRest> {
         message.setIdentifier(messageRest.getIdentifier());
         message.setHeadline(messageRest.getHeadline());
         message.setDescription(messageRest.getDescription());
+        message.setRegionCode(messageRest.getArs());
         message.setPublishedAt(messageRest.getPublishedAt());
         return message;
     }

--- a/src/main/java/de/dealog/msg/rest/MessageResource.java
+++ b/src/main/java/de/dealog/msg/rest/MessageResource.java
@@ -2,24 +2,19 @@ package de.dealog.msg.rest;
 
 import de.dealog.msg.persistence.model.Message;
 import de.dealog.msg.persistence.model.MessageStatus;
-import de.dealog.msg.rest.model.GeoRequest;
-import de.dealog.msg.rest.model.MessageRest;
-import de.dealog.msg.rest.model.PageRequest;
-import de.dealog.msg.rest.model.PagedList;
+import de.dealog.msg.rest.model.*;
 import de.dealog.msg.service.MessageService;
+import de.dealog.msg.service.model.QueryParams;
+import de.dealog.msg.service.model.RegionalCode;
 
 import javax.inject.Inject;
-import javax.ws.rs.BeanParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * REST Resource for {@link Message}s
+ * REST Resource for {@link MessageRest}s
  */
 @Produces("application/de.dealog.service.message-" + MessageResource.API_VERSION)
 @Path(MessageResource.RESOURCE_PATH)
@@ -28,38 +23,57 @@ public class MessageResource {
     public static final String RESOURCE_PATH = "/api/messages";
     public static final String API_VERSION = "v1.0+json";
     public static final String PATH_IDENTIFIER = "identifier";
+    public static final String QUERY_ARS = "ars";
 
     @Inject
     MessageConverter messageConverter;
 
     @Inject
+    RegionalCodeConverter regionalCodeConverter;
+
+    @Inject
     MessageService messageService;
 
     /**
-     * Request {@link Message}s limited by...
-     * @param pageRequest the page request page and page size
-     * @return the list
+     * Returns a paged list of {@link MessageRest}s. Can be filtered by {@link GeoRequest} or an ars
+     *
+     * @param ars the ars as string that should match the messages
+     * @param geoRequest a {@link GeoRequest} containing the long and lat parameter
+     * @param pageRequest a {@link PageRequest} containing the paging parameter
+     * @return the found {@link MessageRest}s
      */
     @GET
-    public Response findAll(@BeanParam final GeoRequest geoRequest, @BeanParam final PageRequest pageRequest) {
+    public Response findAll(
+            @QueryParam(QUERY_ARS) final String ars,
+            @BeanParam final GeoRequest geoRequest,
+            @BeanParam final PageRequest pageRequest) {
 
-        final PagedList<? extends Message> messages = messageService.find(
-                geoRequest.getPoint(), pageRequest.getPage(), pageRequest.getSize());
+        RegionalCode regionalCode = null;
+        if (ars != null) {
+            regionalCode = regionalCodeConverter.doForward(ars);
+        }
+        final QueryParams queryparams = QueryParams.builder()
+                .point(geoRequest.getPoint())
+                .regionalCode(regionalCode)
+                .build();
+        final PagedList<? extends Message> messages = messageService.findAll(
+                queryparams, pageRequest.getPage(), pageRequest.getSize());
         final Iterable<MessageRest> messagesRest = messageConverter.convertAll(messages.getContent());
 
         return Response.ok(messagesRest).build();
     }
 
     /**
-     * Request a {@link Message} by...
-     * @param identifier its unique identifier
-     * @return the message or {@link Response.Status#NOT_FOUND}
+     * Returns a {@link MessageRest} found by identifier
+     *
+     * @param identifier the identifier of the message to find.
+     * @return if found the {@link Response.Status#OK} with {@link MessageRest}, else {@link Response.Status#NOT_FOUND}
      */
     @GET
     @Path("{" + PATH_IDENTIFIER + "}")
     public Response find(@PathParam(PATH_IDENTIFIER) final String identifier) {
 
-        final Optional<Message> message = messageService.find(identifier, MessageStatus.Published);
+        final Optional<Message> message = messageService.findOne(identifier, MessageStatus.Published);
         final AtomicReference<Response> response = new AtomicReference<>();
         message.ifPresentOrElse(
                 m -> response.set(Response.ok(messageConverter.convert(m)).build()),

--- a/src/main/java/de/dealog/msg/rest/RegionConverter.java
+++ b/src/main/java/de/dealog/msg/rest/RegionConverter.java
@@ -1,0 +1,27 @@
+package de.dealog.msg.rest;
+
+import com.google.common.base.Converter;
+import de.dealog.msg.converter.UnsupportedConversionException;
+import de.dealog.msg.persistence.model.Region;
+import de.dealog.msg.rest.model.RegionRest;
+import de.dealog.msg.rest.model.RegionTypeRest;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class RegionConverter extends Converter<Region, RegionRest> {
+
+    @Override
+    protected RegionRest doForward(final Region region) {
+        final RegionRest regionRest = new RegionRest();
+        regionRest.setArs(region.getCode());
+        regionRest.setName(region.getName());
+        regionRest.setType(RegionTypeRest.findByIdentifier(region.getDescription()).orElse(RegionTypeRest.UNKNOWN));
+        return regionRest;
+    }
+
+    @Override
+    protected Region doBackward(final RegionRest regionRest) {
+        throw new UnsupportedConversionException(String.format("Unsupported conversion from %s", regionRest));
+    }
+}

--- a/src/main/java/de/dealog/msg/rest/RegionResource.java
+++ b/src/main/java/de/dealog/msg/rest/RegionResource.java
@@ -1,0 +1,139 @@
+package de.dealog.msg.rest;
+
+import com.google.common.collect.Lists;
+import de.dealog.msg.persistence.model.Region;
+import de.dealog.msg.rest.model.GeoRequest;
+import de.dealog.msg.rest.model.PageRequest;
+import de.dealog.msg.rest.model.PagedList;
+import de.dealog.msg.rest.model.RegionRest;
+import de.dealog.msg.service.RegionService;
+import de.dealog.msg.service.model.QueryParams;
+import de.dealog.msg.service.model.RegionalCode;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotEmpty;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+
+/**
+ * REST Resource for {@link RegionRest}s
+ */
+@Produces("application/de.dealog.service.regions-" + RegionResource.API_VERSION)
+@Path(RegionResource.RESOURCE_PATH)
+public class RegionResource {
+
+    /**
+     * Current API version
+     */
+    public static final String API_VERSION = "v1.0+json";
+
+    /**
+     * Regions path
+     */
+    public static final String RESOURCE_PATH = "/api/regions";
+
+    /**
+     * URI template parameter for ars
+     */
+    public static final String PATH_ARS = "ars";
+
+    /**
+     * URI path for hierarchy
+     */
+    private static final String PATH_HIERACHY ="hierarchy" ;
+
+    /**
+     * Query parameter for name
+     */
+    private static final String QUERY_NAME = "name";
+
+    @Inject
+    RegionConverter regionConverter;
+
+    @Inject
+    RegionalCodeConverter regionalCodeConverter;
+
+    @Inject
+    RegionService regionService;
+
+    /**
+     * Returns the region hierachy of an ARS
+     *
+     * @param ars an ars as string
+     * @param geoRequest a {@link GeoRequest} containing the long and lat parameter
+     * @param pageRequest a {@link PageRequest} containing the paging parameter
+     * @return the hierachy list of {@link RegionRest}s,
+     *          else {@link Response.Status#NOT_FOUND} or {@link Response.Status#BAD_REQUEST}
+     */
+    @GET
+    @Path(PATH_HIERACHY)
+    public Response findHierachy(
+            @QueryParam(PATH_ARS) final String ars,
+            @BeanParam final GeoRequest geoRequest,
+            @BeanParam final PageRequest pageRequest) {
+        final Response build;
+        RegionalCode regionalCode = null;
+        if (ars != null) {
+            regionalCode = regionalCodeConverter.doForward(ars);
+        }
+        final QueryParams queryparams = QueryParams.builder()
+                .point(geoRequest.getPoint())
+                .regionalCode(regionalCode)
+                .build();
+
+        if (queryparams.maybeRegionalCode().isPresent() || queryparams.maybePoint().isPresent()) {
+            final PagedList<? extends Region> regions = regionService.findHierachy(
+                    queryparams, pageRequest.getPage(), pageRequest.getSize());
+            final Iterable<RegionRest> regionRestIterator = regionConverter.convertAll(regions.getContent());
+
+            final ArrayList<RegionRest> regionRests = Lists.newArrayList(regionRestIterator);
+            regionRests.sort(Comparator.comparingInt(a -> a.getType().ordinal()));
+            build = Response.ok(regionRests).build();
+        } else {
+            build = Response.status(Response.Status.BAD_REQUEST).build();
+        }
+        return build;
+    }
+
+    /**
+     * Returns a paged list of regions. Filtered by name
+     *
+     * @param name the name of the regions to find.
+     * @param pageRequest a {@link PageRequest} containing the paging parameter
+     * @return a paged list of {@link RegionRest}s
+     */
+    @GET
+    public Response findAll(
+            @QueryParam(QUERY_NAME) final String name,
+            @BeanParam final PageRequest pageRequest) {
+
+        final PagedList<? extends Region> regions = regionService.findAll(
+                name, pageRequest.getPage(), pageRequest.getSize());
+        final Iterable<RegionRest> messagesRest = regionConverter.convertAll(regions.getContent());
+
+        return Response.ok(messagesRest).build();
+    }
+
+    /**
+     * Returns a {@link RegionRest} found by ars.
+     *
+     * @param ars the ars of the region to find.
+     * @return if found the {@link Response.Status#OK} with {@link RegionRest}, else {@link Response.Status#NOT_FOUND}
+     */
+    @GET
+    @Path("{" + PATH_ARS + "}")
+    public Response find(@NotEmpty @PathParam(PATH_ARS) final String ars) {
+
+        final Optional<Region> region = regionService.findOne(ars);
+        final AtomicReference<Response> response = new AtomicReference<>();
+        region.ifPresentOrElse(
+                r -> response.set(Response.ok(regionConverter.convert(r)).build()),
+                () -> response.set(Response.status(Response.Status.NOT_FOUND).build()));
+        return response.get();
+    }
+}

--- a/src/main/java/de/dealog/msg/rest/RegionalCodeConverter.java
+++ b/src/main/java/de/dealog/msg/rest/RegionalCodeConverter.java
@@ -1,0 +1,70 @@
+package de.dealog.msg.rest;
+
+import com.google.common.base.Converter;
+import de.dealog.msg.service.model.RegionalCode;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Singleton
+@Slf4j
+public class RegionalCodeConverter extends Converter<String, RegionalCode> {
+
+    private static final String COUNTRY = "country";
+    private static final String STATE = "state";
+    private static final String COUNTY = "county";
+    private static final String DISTRICT = "district";
+    private static final String MUNCIPALITY = "muncipality";
+
+    /**
+     * The regex to find the different codes as specfied for the ARS.
+     * {@see https://de.wikipedia.org/wiki/Amtlicher_Gemeindeschl%C3%BCssel#Regionalschl%C3%BCssel}
+     */
+    private static final String CODES_REGEX = "\\b(?<%s>[0-9]{2})(?<%s>[0-9]{1})?(?<%s>[0-9]{2})?(?<%s>[0-9]{4})?(?<%s>[0-9]{3})?\\b";
+
+    Map<String, String> codes = new HashMap<>(Map.of(COUNTRY, "", STATE, "", COUNTY, "", DISTRICT, "", MUNCIPALITY, ""));
+
+    @Override
+    protected RegionalCode doForward(final String ars) {
+
+        final Map<String, String> codes = findCodes(ars);
+
+        return RegionalCode.builder()
+                .country(codes.get(COUNTRY))
+                .state(codes.get(STATE))
+                .county(codes.get(COUNTY))
+                .district(codes.get(DISTRICT))
+                .muncipality(codes.get(MUNCIPALITY))
+                .build();
+    }
+
+    @Override
+    protected String doBackward(final RegionalCode regionalCode) {
+        return String.format("%s%s%s%s%s",
+                regionalCode.getCountry(), regionalCode.getState(), regionalCode.getCounty(), regionalCode.getDistrict(), regionalCode.getMuncipality());
+    }
+
+    /**
+     * Disassembles the ars to regional codes.
+     *
+     * @param ars the ars as string
+     * @return a map containing the regional codes
+     */
+    private Map<String, String> findCodes(final String ars) {
+        log.debug("find codes for ars {}", ars);
+        final String regex = String.format(CODES_REGEX, COUNTRY, STATE, COUNTY, DISTRICT, MUNCIPALITY);
+        final Pattern pattern = Pattern.compile(regex);
+        final Matcher matcher = pattern.matcher(ars);
+
+        while (matcher.find()) {
+            if (matcher.groupCount() == 5) {
+                codes.forEach((groupName, code) -> codes.put(groupName, matcher.group(groupName)));
+            }
+        }
+        return codes;
+    }
+}

--- a/src/main/java/de/dealog/msg/rest/model/GeoRequest.java
+++ b/src/main/java/de/dealog/msg/rest/model/GeoRequest.java
@@ -30,6 +30,11 @@ public class GeoRequest {
     @QueryParam("lat")
     private Double latitude;
 
+    /**
+     * Returns a point, if the longitude and latitude are present.
+     *
+     * @return the {@link Point} representing the long and lat exists.
+     */
     public Point<G2D> getPoint() {
         Point<G2D>  point = null;
         if (longitude != null && latitude != null) {

--- a/src/main/java/de/dealog/msg/rest/model/MessageRest.java
+++ b/src/main/java/de/dealog/msg/rest/model/MessageRest.java
@@ -34,7 +34,12 @@ public class MessageRest {
     private String description;
 
     /**
-     * The createdDate
+     * The regional code "Amtlicher Regionalschlüssel" of the region where this message is valid
+     */
+    private String ars;
+
+    /**
+     * The date the message was published
      */
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
     private Date publishedAt;

--- a/src/main/java/de/dealog/msg/rest/model/RegionRequest.java
+++ b/src/main/java/de/dealog/msg/rest/model/RegionRequest.java
@@ -1,0 +1,21 @@
+package de.dealog.msg.rest.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.ws.rs.QueryParam;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class RegionRequest {
+
+    /**
+     *  The name of the HTTP ars query parameter
+     */
+    public static final String QUERY_ARS = "ars";
+
+    @QueryParam(QUERY_ARS)
+    private String ars;
+}

--- a/src/main/java/de/dealog/msg/rest/model/RegionRest.java
+++ b/src/main/java/de/dealog/msg/rest/model/RegionRest.java
@@ -1,0 +1,28 @@
+package de.dealog.msg.rest.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RegionRest {
+
+    /**
+     * The regional code "Amtlicher Regionalschlüssel"
+     */
+    private String ars;
+
+    /*
+     * The name of the region
+     */
+    private String name;
+
+    /**
+     * The {@link RegionTypeRest} of the region
+     */
+    private RegionTypeRest type;
+}

--- a/src/main/java/de/dealog/msg/rest/model/RegionTypeRest.java
+++ b/src/main/java/de/dealog/msg/rest/model/RegionTypeRest.java
@@ -1,0 +1,36 @@
+package de.dealog.msg.rest.model;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Getter
+public enum RegionTypeRest {
+
+    COUNTRY("Bundesrepublik"),
+    STATE("Land", "Freie Hansestadt", "Freie und Hansestadt", "Freistaat"),
+    COUNTY("Regierungsbezirk"),
+    DISTRICT("Kreis", "Kreisfreie Stadt", "Landkreis", "Stadtkreis"),
+    MUNICIPALITY("Gemeinde", "Gemeindefreies Gebiet", "Stadt"),
+    UNKNOWN;
+
+    private final List<String> identifiers;
+
+    RegionTypeRest(final String... identifiers) {
+        this.identifiers = Arrays.asList(identifiers);
+    }
+
+    /**
+     * Find a region type by an identifer.
+     *
+     * @param identifier the identifier as string
+     * @return an {@link Optional} containing the found {@link RegionTypeRest}
+     */
+    public static Optional<RegionTypeRest> findByIdentifier(final String identifier) {
+        return Arrays.stream(RegionTypeRest.values())
+        .filter(rt -> rt.getIdentifiers().contains(identifier))
+        .findFirst();
+    }
+}

--- a/src/main/java/de/dealog/msg/service/RegionService.java
+++ b/src/main/java/de/dealog/msg/service/RegionService.java
@@ -1,0 +1,99 @@
+package de.dealog.msg.service;
+
+import com.google.common.base.Strings;
+import de.dealog.msg.persistence.model.Region;
+import de.dealog.msg.persistence.model.RegionEntity;
+import de.dealog.msg.persistence.repository.RegionRepository;
+import de.dealog.msg.rest.model.PagedList;
+import de.dealog.msg.service.model.QueryParams;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.quarkus.panache.common.Parameters;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+@NoArgsConstructor
+@Slf4j
+public class RegionService {
+
+    public static final String QUERY_PARAM_POINT = "point";
+
+    @Inject
+    RegionRepository regionRepository;
+
+    public Optional<Region> findOne(final String ars) {
+        log.debug("Find region by ars {}", ars);
+        final RegionEntity byIdentifier = regionRepository.findByArs(ars);
+        return Optional.ofNullable(byIdentifier);
+    }
+
+    public PagedList<? extends Region> findAll(final String name, final int page, final int size) {
+        log.debug("List regions for page {}, size {} and name '{}' ...", page, size, name);
+        final PanacheQuery<RegionEntity> regionQuery;
+
+        String query = "";
+        if(!Strings.isNullOrEmpty(name)) {
+            query = "select r from RegionEntity r where lower(name) like '%" + name.toLowerCase() + "%'";
+        }
+        regionQuery = regionRepository.find(query);
+
+        final List<RegionEntity> list = regionQuery.page(page, size).list();
+
+        log.debug("... return {} / {} regions ", list.size(), regionQuery.count());
+
+        return PagedList.<Region>builder()
+                .page(page)
+                .pageSize(size)
+                .content(list)
+                .count(regionQuery.count())
+                .pageCount(regionQuery.pageCount())
+                .build();
+    }
+
+    public PagedList<? extends Region> findHierachy(final QueryParams queryParams, final int page, final int size) {
+        log.debug("List regions for page {}, size {} and queryParams '{}' ...", page, size, queryParams);
+        final PanacheQuery<RegionEntity> regionQuery;
+        final StringBuilder queryBuilder = new StringBuilder();
+        final Parameters parameters = new Parameters();
+
+        final List<String> codes = new ArrayList<>(Arrays.asList("000000000000"));
+        queryParams.maybeRegionalCode().ifPresent(regionalCode -> {
+            regionalCode.getRegionalCountry().ifPresent(codes::add);
+            regionalCode.getRegionalState().ifPresent(codes::add);
+            regionalCode.getRegionalCounty().ifPresent(codes::add);
+            regionalCode.getRegionalDistrict().ifPresent(codes::add);
+            regionalCode.getRegionalMuncipality().ifPresent(codes::add);
+
+            queryBuilder.append(" ars IN (")
+                    .append(codes.stream().map(c -> ("'" + c + "'")).collect(Collectors.joining(",")))
+                    .append(") ");
+        });
+
+        queryParams.maybePoint().ifPresent(point -> {
+            parameters.and(QUERY_PARAM_POINT, point);
+            queryBuilder.append(" within(:point, geometries) = true");
+        });
+
+        regionQuery = regionRepository.find(queryBuilder.toString(), parameters);
+
+        final List<RegionEntity> list = regionQuery.page(page, size).list();
+
+        log.debug("... return {} / {} regions ", list.size(), regionQuery.count());
+
+        return PagedList.<Region>builder()
+                .page(page)
+                .pageSize(size)
+                .content(list)
+                .count(regionQuery.count())
+                .pageCount(regionQuery.pageCount())
+                .build();
+    }
+}

--- a/src/main/java/de/dealog/msg/service/model/QueryParams.java
+++ b/src/main/java/de/dealog/msg/service/model/QueryParams.java
@@ -1,0 +1,25 @@
+package de.dealog.msg.service.model;
+
+import lombok.Builder;
+import lombok.ToString;
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.Point;
+
+import java.util.Optional;
+
+@Builder
+@ToString
+public class QueryParams {
+
+    private final RegionalCode regionalCode;
+
+    private final Point<G2D> point;
+
+    public Optional<RegionalCode> maybeRegionalCode() {
+        return Optional.ofNullable(regionalCode);
+    }
+
+    public Optional<Point<G2D>> maybePoint() {
+        return Optional.ofNullable(point);
+    }
+}

--- a/src/main/java/de/dealog/msg/service/model/RegionalCode.java
+++ b/src/main/java/de/dealog/msg/service/model/RegionalCode.java
@@ -1,0 +1,69 @@
+package de.dealog.msg.service.model;
+
+import com.google.common.base.Strings;
+import lombok.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@ToString
+public class RegionalCode {
+    /**
+     * 1.–2. Stelle   = Kennzahl des Bundeslandes
+     */
+    private String country;
+
+    /**
+     * 3. Stelle      = Kennzahl des Regierungsbezirks; wenn nicht vorhanden: 0
+     */
+    private String state;
+
+    /**
+     * 4.–5. Stelle   = Kennzahl des Landkreises oder der kreisfreien Stadt
+     */
+    private String county;
+
+    /**
+     * 6.–9. Stelle   = Verbandsschlüssel
+     */
+    private String district;
+
+    /**
+     * 10.–12. Stelle = Gemeindekennzahl
+     */
+    private String muncipality;
+    public Optional<String>  getRegionalCountry(){
+        return buildRegionalArs(Collections.singletonList(country));
+    }
+    public Optional<String>  getRegionalState(){
+        return buildRegionalArs(Arrays.asList(country, state));
+    }
+
+    public Optional<String>  getRegionalCounty(){
+        return buildRegionalArs(Arrays.asList(country, state, county));
+    }
+
+    public Optional<String> getRegionalDistrict(){
+        return buildRegionalArs(Arrays.asList(country, state, county, district));
+    }
+
+    public Optional<String> getRegionalMuncipality(){
+        return buildRegionalArs(Arrays.asList(country, state, county, district, muncipality));
+    }
+
+    private Optional<String> buildRegionalArs(final List<String> regionalCodes){
+        String result = null;
+        if (regionalCodes.size() > 0 && !Strings.isNullOrEmpty(regionalCodes.get(regionalCodes.size() -1))) {
+            final StringBuilder pattern = new StringBuilder();
+            regionalCodes.forEach(s -> pattern.append("%s"));
+            result = String.format(pattern.toString(), regionalCodes.toArray());
+        }
+        return Optional.ofNullable(result);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,10 +4,18 @@ quarkus.datasource.username = docker
 quarkus.datasource.password = docker
 quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:25432/gis
 
-# drop and create the database at startup (use `update` to only update the schema)
 quarkus.hibernate-orm.dialect=org.hibernate.spatial.dialect.postgis.PostgisDialect
-quarkus.hibernate-orm.database.generation = drop-and-create
 quarkus.hibernate-orm.jdbc.timezone=UTC
+
+# drop and create the database at startup (use `update` to only update the schema)
+%dev.quarkus.hibernate-orm.database.generation = drop-and-create
+
+%dev-with-vg250.quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:15432/postgis
+%dev-with-vg250.quarkus.hibernate-orm.database.generation = update
+%dev-with-vg250.quarkus.hibernate-orm.sql-load-script = import-dev.sql
+
+%prod.quarkus.hibernate-orm.database.generation = none
+%prod.quarkus.hibernate-orm.sql-load-script = no-file
 
 quarkus.log.level=INFO
 quarkus.log.category."de.dealog".level=DEBUG

--- a/src/main/resources/import-dev.sql
+++ b/src/main/resources/import-dev.sql
@@ -1,0 +1,11 @@
+CREATE MATERIALIZED VIEW public.vg250_compound AS
+SELECT
+    row_number() OVER (ORDER BY ars) AS id,
+    *
+FROM (
+     SELECT DISTINCT ON (ars) ars, gen, bez, geom FROM public.vg250_sta
+        UNION SELECT DISTINCT ON (ars) ars, gen, bez, geom FROM public.vg250_lan
+        UNION SELECT DISTINCT ON (ars) ars, gen, bez, geom FROM public.vg250_rbz
+        UNION SELECT DISTINCT ON (ars) ars, gen, bez, geom FROM public.vg250_krs
+        UNION SELECT DISTINCT ON (ars) ars, gen, bez, geom FROM public.vg250_gem
+) as foo

--- a/src/test/java/de/dealog/msg/TestUtils.java
+++ b/src/test/java/de/dealog/msg/TestUtils.java
@@ -1,8 +1,11 @@
 package de.dealog.msg;
 
+import de.dealog.msg.persistence.model.RegionEntity;
 import de.dealog.msg.persistence.model.GeocodeEntity;
 import de.dealog.msg.persistence.model.MessageEntity;
+import de.dealog.msg.rest.model.RegionRest;
 import de.dealog.msg.rest.model.MessageRest;
+import de.dealog.msg.rest.model.RegionTypeRest;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.geolatte.geom.G2D;
 import org.geolatte.geom.MultiPolygon;
@@ -13,18 +16,19 @@ import java.util.Date;
 
 public class TestUtils {
 
-    public static MessageEntity buildMessage(final String identifier, final String headline, final String description) {
-        MessageEntity message = new MessageEntity();
-        message.setGeocode(buildGeocode());
+    public static MessageEntity buildMessage(final String identifier, final String headline, final String description, final String regionCode) {
+        final MessageEntity message = new MessageEntity();
         message.setIdentifier(identifier);
         message.setDescription(description);
         message.setHeadline(headline);
+        message.setRegionCode(regionCode);
+        message.setGeocode(buildGeocode());
         message.setPublishedAt(new Date());
         return message;
     }
 
     public static GeocodeEntity buildGeocode () {
-        String wkt = "MULTIPOLYGON (((11.795583 51.385388, 11.813135 51.398215, 11.827426 51.396073, 11.823821 51.391842, 11.795583 51.385388)))";
+        final String wkt = "MULTIPOLYGON (((11.795583 51.385388, 11.813135 51.398215, 11.827426 51.396073, 11.823821 51.391842, 11.795583 51.385388)))";
         return GeocodeEntity.builder()
                 .polygons((MultiPolygon<G2D>) Wkt.newDecoder(Wkt.Dialect.POSTGIS_EWKT_1).decode(wkt, CoordinateReferenceSystems.WGS84))
                 .hash(DigestUtils.md5Hex(wkt))
@@ -32,11 +36,27 @@ public class TestUtils {
     }
 
     public static MessageRest buildMessageRest(final String identifier, final String headline, final String description) {
-        MessageRest messageRest = new MessageRest();
+        final MessageRest messageRest = new MessageRest();
         messageRest.setIdentifier(identifier);
         messageRest.setDescription(description);
         messageRest.setHeadline(headline);
         messageRest.setPublishedAt(new Date());
         return messageRest;
+    }
+
+    public static RegionRest buildRegionRest(final String ars, final String name, final RegionTypeRest regionTypeRest) {
+        final RegionRest regionRest = new RegionRest();
+        regionRest.setArs(ars);
+        regionRest.setName(name);
+        regionRest.setType(regionTypeRest);
+        return regionRest;
+    }
+
+    public static RegionEntity buildRegion(final String code, final String name, final String description) {
+        final RegionEntity regionEntity = new RegionEntity();
+        regionEntity.setCode(code);
+        regionEntity.setName(name);
+        regionEntity.setDescription(description);
+        return regionEntity;
     }
 }

--- a/src/test/java/de/dealog/msg/rest/MessageConverterTest.java
+++ b/src/test/java/de/dealog/msg/rest/MessageConverterTest.java
@@ -20,16 +20,16 @@ class MessageConverterTest {
 
     @Test
     void doForward() {
-        Message message = TestUtils.buildMessage("1", "This is the headline", "This is the description");
+        Message message = TestUtils.buildMessage("1", "This is the headline", "This is the description", "091790134134");
         MessageRest messageRest = messageConverter.doForward(message);
         assert messageRest != null;
         assertEquals(message.getIdentifier(), messageRest.getIdentifier());
         assertEquals(message.getHeadline(), messageRest.getHeadline());
         assertEquals(message.getDescription(), messageRest.getDescription());
 
-        Message msg_one = TestUtils.buildMessage("1", "This is the headline", "This is the description");
-        Message msg_two = TestUtils.buildMessage("10", "This is the second headline", "This is the second description");
-        Message msg_three = TestUtils.buildMessage("100", "This is the third headline", "This is the third description");
+        Message msg_one = TestUtils.buildMessage("1", "This is the headline", "This is the description", "091790134134");
+        Message msg_two = TestUtils.buildMessage("10", "This is the second headline", "This is the second description", "091790134134");
+        Message msg_three = TestUtils.buildMessage("100", "This is the third headline", "This is the third description", "091790134134");
         Iterable<MessageRest> messageRests = messageConverter.convertAll(Arrays.asList(msg_one, msg_two, msg_three));
 
         int size = Iterators.size(messageRests.iterator());

--- a/src/test/java/de/dealog/msg/rest/MessageResourceTest.java
+++ b/src/test/java/de/dealog/msg/rest/MessageResourceTest.java
@@ -6,6 +6,7 @@ import de.dealog.msg.persistence.model.MessageStatus;
 import de.dealog.msg.rest.model.PageRequest;
 import de.dealog.msg.rest.model.PagedList;
 import de.dealog.msg.service.MessageService;
+import de.dealog.msg.service.model.QueryParams;
 import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -19,6 +20,8 @@ import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
 
 @QuarkusTest
@@ -36,16 +39,16 @@ class MessageResourceTest {
 
     @BeforeAll
     public static void setup() {
-        Message msg_one = TestUtils.buildMessage(UUID_ONE, "This is the headline", "This is the description");
-        Message msg_two = TestUtils.buildMessage(UUID_TWO, "This is the second headline", "This is the second description");
-        Message msg_three = TestUtils.buildMessage(UUID_THREE, "This is the third headline", "This is the third description");
+        Message msg_one = TestUtils.buildMessage(UUID_ONE, "This is the headline", "This is the description", "091790134134");
+        Message msg_two = TestUtils.buildMessage(UUID_TWO, "This is the second headline", "This is the second description", "091790134134");
+        Message msg_three = TestUtils.buildMessage(UUID_THREE, "This is the third headline", "This is the third description", "091790134134");
         PagedList<? extends Message> pagedList = PagedList.<Message>builder()
                 .page(0).pageSize(10).pageCount(1).count(666).content(Arrays.asList(msg_one, msg_two, msg_three)).build();
         MessageService messageService = Mockito.mock(MessageService.class);
 
-        doReturn(pagedList).when(messageService).find(null, 0, 10);
+        doReturn(pagedList).when(messageService).findAll(any(QueryParams.class), anyInt(), anyInt());
 
-        doReturn(Optional.of(msg_one)).when(messageService).find(UUID_ONE, MessageStatus.Published);
+        doReturn(Optional.of(msg_one)).when(messageService).findOne(UUID_ONE, MessageStatus.Published);
 
         QuarkusMock.installMockForType(messageService, MessageService.class);
     }

--- a/src/test/java/de/dealog/msg/rest/RegionConverterTest.java
+++ b/src/test/java/de/dealog/msg/rest/RegionConverterTest.java
@@ -1,0 +1,54 @@
+package de.dealog.msg.rest;
+
+import com.google.common.collect.Iterators;
+import de.dealog.msg.TestUtils;
+import de.dealog.msg.converter.UnsupportedConversionException;
+import de.dealog.msg.persistence.model.Region;
+import de.dealog.msg.rest.model.RegionRest;
+import de.dealog.msg.rest.model.RegionTypeRest;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@QuarkusTest
+class RegionConverterTest {
+
+    @Inject
+    RegionConverter regionConverter;
+
+    @Test
+    void doForward() {
+        final Region region = TestUtils.buildRegion("000000000000", "Deutschland", "Bundesrepublik");
+        final RegionRest regionRest = regionConverter.doForward(region);
+        assert regionRest != null;
+        assertEquals(regionRest.getArs(), region.getCode());
+        assertEquals(regionRest.getName(), region.getName());
+        assertThat(RegionTypeRest.COUNTRY.getIdentifiers(), hasItem(region.getDescription()));
+
+        Region region_one = TestUtils.buildRegion("000000000000", "Deutschland", "Bundesrepublik");
+        Region region_two = TestUtils.buildRegion("03355", "Lüneburg", "Landkreis");
+        Region region_three = TestUtils.buildRegion("010510044044", "Heide", "Stadt");
+        Iterable<RegionRest> districtRests = regionConverter.convertAll(Arrays.asList(region_one, region_two, region_three));
+
+        int size = Iterators.size(districtRests.iterator());
+        assertEquals(3, size);
+        RegionRest regionRest_three = Iterators.get(districtRests.iterator(), 2);
+
+        assertEquals(region_three.getCode(), regionRest_three.getArs());
+        assertEquals(region_three.getName(), regionRest_three.getName());
+        assertThat(regionRest_three.getType().getIdentifiers(), hasItem(region_three.getDescription()));
+    }
+
+    @Test
+    void doBackward() {
+        RegionRest regionRest = TestUtils.buildRegionRest("000000000000", "Deutschland", RegionTypeRest.COUNTRY);
+        assertThrows(UnsupportedConversionException.class, () -> regionConverter.doBackward(regionRest));
+    }
+}

--- a/src/test/java/de/dealog/msg/rest/RegionResourceTest.java
+++ b/src/test/java/de/dealog/msg/rest/RegionResourceTest.java
@@ -1,0 +1,62 @@
+package de.dealog.msg.rest;
+
+import de.dealog.msg.TestUtils;
+import de.dealog.msg.persistence.model.Region;
+import de.dealog.msg.rest.model.PageRequest;
+import de.dealog.msg.rest.model.PagedList;
+import de.dealog.msg.rest.model.RegionTypeRest;
+import de.dealog.msg.service.RegionService;
+import de.dealog.msg.service.model.QueryParams;
+import io.quarkus.test.junit.QuarkusMock;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+
+@QuarkusTest
+class RegionResourceTest {
+
+    @Inject
+    RegionService regionService;
+
+    @Inject
+    RegionConverter regionConverter;
+
+    @BeforeAll
+    public static void setup() {
+        final Region region_one = TestUtils.buildRegion("03355", "Lüneburg", "Landkreis");
+        final Region region_two = TestUtils.buildRegion("000000000000", "Deutschland", "Bundesrepublik");
+        final Region region_three = TestUtils.buildRegion("010510044044", "Heide", "Stadt");
+        final PagedList<? extends Region> pagedList = PagedList.<Region>builder()
+                .page(0).pageSize(10).pageCount(1).count(666).content(Arrays.asList(region_one, region_two, region_three)).build();
+        final RegionService regionService = Mockito.mock(RegionService.class);
+
+        doReturn(pagedList).when(regionService).findHierachy(any(QueryParams.class), anyInt(), anyInt());
+
+        QuarkusMock.installMockForType(regionService, RegionService.class);
+    }
+
+    @Test
+    void findHierachy() {
+       given()
+                .param(PageRequest.PAGE, 0)
+                .param(PageRequest.SIZE, 10)
+                .when().get("/api/regions/hierarchy?ars=091790134135")
+                .then()
+                .statusCode(200)
+                .body(startsWith("[{\"ars\":\"000000000000\""))
+                .body(containsString("\"type\":\""+ RegionTypeRest.COUNTRY.name() + "\""))
+                .body(containsString("\"type\":\""+ RegionTypeRest.DISTRICT.name() + "\""))
+                .body(containsString("\"type\":\""+ RegionTypeRest.MUNICIPALITY.name() + "\""))
+                .body(endsWith("\"type\":\"MUNICIPALITY\"}]"));
+    }
+}

--- a/src/test/java/de/dealog/msg/rest/RegionalCodeConverterTest.java
+++ b/src/test/java/de/dealog/msg/rest/RegionalCodeConverterTest.java
@@ -1,0 +1,52 @@
+package de.dealog.msg.rest;
+
+import de.dealog.msg.service.model.RegionalCode;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@QuarkusTest
+class RegionalCodeConverterTest {
+
+    @Inject
+    RegionalCodeConverter regionalCodeConverter;
+
+    @Test
+    void convertMuncipality() {
+        final RegionalCode regionalCode = regionalCodeConverter.doForward("091790134134");
+        assert regionalCode != null;
+        assertThat(regionalCode.getCountry(), is("09"));
+        assertThat(regionalCode.getState(), is("1"));
+        assertThat(regionalCode.getCounty(), is("79"));
+        assertThat(regionalCode.getDistrict(), is("0134"));
+        assertThat(regionalCode.getMuncipality(), is("134"));
+        assertThat(regionalCode.getRegionalMuncipality().get(), is("091790134134"));
+    }
+
+    @Test
+    void convertDistrict() {
+        final RegionalCode regionalCode = regionalCodeConverter.doForward("091790134");
+        assert regionalCode != null;
+        assertThat(regionalCode.getCountry(), is("09"));
+        assertThat(regionalCode.getState(), is("1"));
+        assertThat(regionalCode.getCounty(), is("79"));
+        assertThat(regionalCode.getDistrict(), is("0134"));
+        assertThat(regionalCode.getRegionalMuncipality().isPresent(), is(false));
+    }
+
+    @Test
+    void doBackward() {
+        final RegionalCode regionalCode = RegionalCode.builder()
+                .country("12")
+                .state("0")
+                .county("64")
+                .district("5410")
+                .muncipality("340")
+                .build();
+        assertThat(regionalCodeConverter.doBackward(regionalCode), is("120645410340"));
+    }
+}

--- a/src/test/java/de/dealog/msg/service/RegionServiceTest.java
+++ b/src/test/java/de/dealog/msg/service/RegionServiceTest.java
@@ -1,0 +1,63 @@
+package de.dealog.msg.service;
+
+import de.dealog.msg.TestUtils;
+import de.dealog.msg.persistence.model.Region;
+import de.dealog.msg.persistence.repository.RegionRepository;
+import de.dealog.msg.rest.model.PagedList;
+import de.dealog.msg.service.model.QueryParams;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.quarkus.panache.common.Parameters;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@QuarkusTest
+class RegionServiceTest {
+
+    public static final int PAGE_NUMBER_ONE = 1;
+    public static final int PAGE_SIZE_3 = 3;
+    public static final long TOTAL_COUNT = Long.MAX_VALUE;
+
+    @Inject
+    RegionService regionService;
+
+    @InjectMock
+    RegionRepository regionRepository;
+
+    @Test
+    void findRegions() {
+        Region region_one = TestUtils.buildRegion("000000000000", "Deutschland", "Bundesrepublik");
+        Region region_two = TestUtils.buildRegion("03355", "Lüneburg", "Landkreis");
+        Region region_three = TestUtils.buildRegion("010510044044", "Heide", "Stadt");
+
+        List<Region> regions = Arrays.asList(region_one, region_two, region_three);
+
+        PanacheQuery query = Mockito.mock(PanacheQuery.class);
+        PanacheQuery queryPage = Mockito.mock(PanacheQuery.class);
+        when(queryPage.list()).thenReturn(regions);
+
+        int pageCount = (int) (TOTAL_COUNT / PAGE_SIZE_3);
+        when(query.pageCount()).thenReturn(pageCount);
+        when(query.page(1, PAGE_SIZE_3)).thenReturn(queryPage);
+        when(query.count()).thenReturn(TOTAL_COUNT);
+        when(regionRepository.find(anyString(), any(Parameters.class))).thenReturn(query);
+
+        PagedList<? extends Region> list = regionService.findHierachy(QueryParams.builder().build(), PAGE_NUMBER_ONE, PAGE_SIZE_3);
+
+        assertThat(PAGE_NUMBER_ONE, is(list.getPage()));
+        assertThat(regions.size(), is(list.getPageSize()));
+        assertThat(TOTAL_COUNT, is(list.getCount()));
+        assertThat(pageCount, is(list.getPageCount()));
+    }
+}


### PR DESCRIPTION
 Add region persistence and rest resources
    
    - Add query param "ars" and extend find messages to search messages by point or ars
    - Add region model, persistence and rest methods to
            - find a region by name
            - find regions (optional filtered by name)
            - find a region hierachy by arsand point
    - Add import-sql script that creates a materialzied views of regions. Regions read-only.
    - Add new profile "dev-with-vg250" to use the "admin-region-import" DB as datasource
    DEV-135-ars

