### PR TITLE
add permissions to execute the application

### DIFF
--- a/src/main/docker/Dockerfile.native
+++ b/src/main/docker/Dockerfile.native
@@ -16,10 +16,11 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 WORKDIR /work/
-RUN chown 1001 /work \
-    && chmod "g+rwX" /work \
-    && chown 1001:root /work
-COPY --chown=1001:root target/*-runner /work/application
+COPY target/*-runner ./application
+RUN chmod 775 /work /work/application \
+    && chown -R 1001 /work \
+    && chmod -R "g+rwX" /work \
+    && chown -R 1001:root /work
 
 EXPOSE 8080
 USER 1001


### PR DESCRIPTION
It seems there is some inconsistencies between Dockerfile.native and the docs: https://quarkus.io/guides/building-native-image#using-a-multi-stage-docker-build

Without the executable file attribute the application is not starting.
