### PR TITLE
Add message request tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.0 (under development)
 This is the initial version setting up the base system
 
+- `NEW` Add single and list message request tracking
 - `NEW` Add REST parameter validations
 - `NEW` Add max page size to 50
 - `NEW` Add 0.0.0 as unsupported version

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,10 @@
       <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-vertx</artifactId>
+    </dependency>
+    <dependency>
       <groupId>de.dealog</groupId>
       <artifactId>dealog-common</artifactId>
       <version>${dealog-common.version}</version>

--- a/src/main/java/de/dealog/msg/messaging/message/MessageEventConsumer.java
+++ b/src/main/java/de/dealog/msg/messaging/message/MessageEventConsumer.java
@@ -1,4 +1,4 @@
-package de.dealog.msg.event;
+package de.dealog.msg.messaging.message;
 
 import de.dealog.common.model.MessageEvent;
 import de.dealog.msg.geometry.UnsupportedGeometryException;
@@ -16,7 +16,7 @@ import javax.inject.Inject;
 
 @ApplicationScoped
 @Slf4j
-public class MessageEventHandler {
+public class MessageEventConsumer {
 
     @Inject
     MessageEventPayloadConverter messageEventPayloadConverter;

--- a/src/main/java/de/dealog/msg/messaging/message/MessageEventPayloadConverter.java
+++ b/src/main/java/de/dealog/msg/messaging/message/MessageEventPayloadConverter.java
@@ -1,4 +1,4 @@
-package de.dealog.msg.event;
+package de.dealog.msg.messaging.message;
 
 import com.google.common.base.Converter;
 import de.dealog.common.model.MessageEventPayload;

--- a/src/main/java/de/dealog/msg/messaging/tracking/MessageTracking.java
+++ b/src/main/java/de/dealog/msg/messaging/tracking/MessageTracking.java
@@ -1,0 +1,27 @@
+package de.dealog.msg.messaging.tracking;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+/**
+ * The message tracking
+ */
+@Getter
+@Setter
+public class MessageTracking implements Serializable {
+
+    private static final long serialVersionUID = 123L;
+
+    /**
+     * The {@link MessageTrackingType} of the message tracking
+     */
+    private MessageTrackingType type;
+
+    /**
+     * The payload containing the message tracking
+     */
+    private MessageTrackingPayload payload;
+
+}

--- a/src/main/java/de/dealog/msg/messaging/tracking/MessageTrackingBroadcaster.java
+++ b/src/main/java/de/dealog/msg/messaging/tracking/MessageTrackingBroadcaster.java
@@ -1,0 +1,54 @@
+package de.dealog.msg.messaging.tracking;
+
+import io.quarkus.vertx.ConsumeEvent;
+import io.vertx.core.json.JsonArray;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+@ApplicationScoped
+@Slf4j
+public class MessageTrackingBroadcaster {
+
+    public static final String MESSAGE_SINGLE_REQUEST = "message-single-request";
+
+    public static final String MESSAGE_LIST_REQUEST = "message-list-request";
+
+    @Inject
+    @Channel("message-tracking")
+    Emitter<MessageTracking> viewEmitter;
+
+    @ConsumeEvent(MESSAGE_SINGLE_REQUEST)
+    public void consume(final String id) {
+        if (StringUtils.isNotEmpty(id)) {
+            broadcast(Collections.singletonList(id), MessageTrackingType.SingleMessageRequested);
+        }
+    }
+
+    @ConsumeEvent(MESSAGE_LIST_REQUEST)
+    public void consume(final JsonArray json) {
+        if (json != null) {
+            final List ids = json.getList();
+            broadcast(ids, MessageTrackingType.ListRequested);
+        }
+    }
+
+    private void broadcast(final List<String> ids, final MessageTrackingType type) {
+        final MessageTrackingPayload payload = new MessageTrackingPayload();
+        payload.setIds(ids);
+        payload.setTrackedAt(new Date());
+
+        final MessageTracking messageTracking = new MessageTracking();
+        messageTracking.setType(type);
+        messageTracking.setPayload(payload);
+        log.debug("Send message tracking event '{}'", messageTracking.getType());
+        viewEmitter.send(messageTracking);
+    }
+}

--- a/src/main/java/de/dealog/msg/messaging/tracking/MessageTrackingPayload.java
+++ b/src/main/java/de/dealog/msg/messaging/tracking/MessageTrackingPayload.java
@@ -1,0 +1,29 @@
+package de.dealog.msg.messaging.tracking;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * The payload contains the data of the message
+ */
+@Getter
+@Setter
+@ToString
+public class MessageTrackingPayload {
+
+    /**
+     * A list of tracked message ids
+     */
+    private List<String> ids;
+
+    /**
+     * The date and time when the message request was tracked in UTC
+     */
+    private Date trackedAt;
+}
+
+

--- a/src/main/java/de/dealog/msg/messaging/tracking/MessageTrackingType.java
+++ b/src/main/java/de/dealog/msg/messaging/tracking/MessageTrackingType.java
@@ -1,0 +1,17 @@
+package de.dealog.msg.messaging.tracking;
+
+/**
+ * The available message tracking types
+ */
+public enum MessageTrackingType {
+
+    /**
+     * A single message is requested
+     */
+    SingleMessageRequested,
+
+    /**
+     * A list of messages are requested
+     */
+    ListRequested;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,4 +40,8 @@ mp.messaging.incoming.messages.connector=smallrye-kafka
 mp.messaging.incoming.messages.topic=messages
 mp.messaging.incoming.messages.value.deserializer=de.dealog.common.serialization.MessageEventDeserializer
 
+mp.messaging.outgoing.message-tracking.connector=smallrye-kafka
+mp.messaging.outgoing.message-tracking.topic=message-tracking
+mp.messaging.outgoing.message-tracking.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
+
 dealog.api.version.unsupported=0.0.0

--- a/src/test/java/de/dealog/msg/rest/MessageResourceTest.java
+++ b/src/test/java/de/dealog/msg/rest/MessageResourceTest.java
@@ -49,7 +49,6 @@ class MessageResourceTest {
         MessageService messageService = Mockito.mock(MessageService.class);
 
         doReturn(pagedList).when(messageService).findAll(any(QueryParams.class), anyInt(), anyInt());
-
         doReturn(Optional.of(msg_one)).when(messageService).findOne(UUID_ONE, MessageStatus.Published);
 
         QuarkusMock.installMockForType(messageService, MessageService.class);


### PR DESCRIPTION
Tracked are the message ids of single and list requests with a timesstamp when the request was processed.
The tracking events are send to the topic "message-tracking".

DEV-147