### PR TITLE
Bump quarkus from 1.9.2.Final to 1.13.6.Final.

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -35,7 +35,7 @@ jobs:
         uses: ayltai/setup-graalvm@v1
         with:
           java-version: 11
-          graalvm-version: 20.2.0
+          graalvm-version: 21.1.0
 
       - name: Create settings.xml
         uses: whelk-io/maven-settings-xml-action@v9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 1.0.0 (under development)
 This is the initial version setting up the base system
 
+<<<<<<< HEAD
+=======
+- 'CNG' Bump quarkus to 1.23.6 and GraalVM to 21.1.0
 - 'CNG' Fix typo hierachy -> hierarchy. In fieldnames, methods and comments
 - 'NEW' Enable REST data for messages and regions
 - 'CNG' Find messages for the region code hierarchy

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.9.2.Final</quarkus.platform.version>
-    <quarkus-plugin.version>1.9.2.Final</quarkus-plugin.version>
+    <quarkus.platform.version>1.13.6.Final</quarkus.platform.version>
+    <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
     <rest-assured.version>4.4.0</rest-assured.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>


### PR DESCRIPTION
Bumps quarkus-platform and quarkus-maven-plugin from 1.9.2.Final to 1.13.6.Final.