### PR TITLE
Bump Quarkus version and replace kafka w/ RabbitMQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 1.0.0 (under development)
-This is the initial version setting up the base system
+## 2.0.0
+- Change reactive messaging from kafka to amqp
+- Bump Quarkus from 1.13.6.Final to 2.2.2.Final
 
-<<<<<<< HEAD
-=======
+## 1.0.0 (under development)
 - 'CNG' Bump quarkus to 1.23.6 and GraalVM to 21.1.0
 - 'CNG' Fix typo hierachy -> hierarchy. In fieldnames, methods and comments
 - 'NEW' Enable REST data for messages and regions

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ prerequisites needed to get the application up and running locally.
 ### Requirements
 
 - [Maven](https://maven.apache.org/) for building the project
+- [RabbitMQ](https://www.rabbitmq.com)
 - [OpenJDK >= 11.0.x](https://openjdk.java.net/) to develop and deploy the application
 - [Docker](https://docker.io) for running the code
 - Editor for coding
@@ -23,9 +24,8 @@ prerequisites needed to get the application up and running locally.
 
 ### ... in dev mode
 
-- Start an Apache Kafka
+- Start an RabbitMQ with AMQP 1.0 plugin. You can use DEalog RabbitMQ Dockerfile e.g. the (https://github.com/DEalog/rabbitmq-amqp1)
 
-You can use DEalog Kafka Development Cluster e.g. the (https://github.com/DEalog/dealog-kafka-dev-cluster)
 - Start Postgres
 ```
 . docker run --name "postgis" -p 25432:5432 -d -t kartoza/postgis
@@ -68,7 +68,7 @@ If you want to collaborate please follow this guide:
 The DEalog Message service uses the following (main) technologies, frameworks and libraries:
 
 - [Quarkus](https://quarkus.io/)
-- [APACHE KAFKA](https://kafka.apache.org)
+- [RabbitMQ](https://www.rabbitmq.com)
 - [Postgres](https://www.postgresql.org)
 - [Project Lombok](https://projectlombok.org/)
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.dealog</groupId>
   <artifactId>dealog-message-service</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <properties>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <dealog-common.version>1.0.0-SNAPSHOT</dealog-common.version>
@@ -18,10 +18,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.13.6.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.2.2.Final</quarkus.platform.version>
     <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
     <rest-assured.version>4.4.0</rest-assured.version>
-    <surefire-plugin.version>2.22.2</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -57,10 +57,6 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-mutiny</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-orm-panache</artifactId>
     </dependency>
     <dependency>
@@ -86,11 +82,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-vertx</artifactId>
+      <artifactId>quarkus-smallrye-reactive-messaging-amqp</artifactId>
     </dependency>
     <dependency>
       <groupId>de.dealog</groupId>
@@ -151,6 +143,8 @@
           <execution>
             <goals>
               <goal>build</goal>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
             </goals>
           </execution>
         </executions>

--- a/src/main/java/de/dealog/msg/messaging/message/MessageEventConsumer.java
+++ b/src/main/java/de/dealog/msg/messaging/message/MessageEventConsumer.java
@@ -1,19 +1,19 @@
 package de.dealog.msg.messaging.message;
 
 import de.dealog.common.messaging.message.MessageEvent;
+import de.dealog.common.model.Status;
 import de.dealog.msg.converter.MessageEventPayloadConverter;
 import de.dealog.msg.geometry.UnsupportedGeometryException;
 import de.dealog.msg.persistence.model.Message;
-import de.dealog.common.model.Status;
 import de.dealog.msg.service.MessageService;
 import io.smallrye.reactive.messaging.annotations.Blocking;
+import io.vertx.core.json.JsonObject;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.Validate;
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 
 @ApplicationScoped
 @Slf4j
@@ -33,7 +33,9 @@ public class MessageEventConsumer {
     @Incoming("messages")
     @Blocking
     @Acknowledgment(Acknowledgment.Strategy.PRE_PROCESSING)
-    public void process(final MessageEvent messageEvent) {
+    public void process(final JsonObject eventJson) {
+
+        MessageEvent messageEvent = eventJson.mapTo(MessageEvent.class);
         log.debug("Received message event type '{}'", messageEvent.getType());
 
         Message message = null;

--- a/src/main/java/de/dealog/msg/rest/MessageResource.java
+++ b/src/main/java/de/dealog/msg/rest/MessageResource.java
@@ -98,7 +98,7 @@ public class MessageResource {
                 queryparams, pageRequest.getPage(), pageRequest.getSize());
 
         if(messages.getContent().size() > 0) {
-            eventBus.sendAndForget(MessageTrackingBroadcaster.MESSAGE_LIST_REQUEST,
+            eventBus.send(MessageTrackingBroadcaster.MESSAGE_LIST_REQUEST,
                     new JsonArray(messages.getContent().stream().map(Message::getIdentifier).collect(Collectors.toList())));
         }
         final PagedListRest<MessageRest> response = pagedListConverter.convert(messages);
@@ -119,7 +119,7 @@ public class MessageResource {
         final AtomicReference<Response> response = new AtomicReference<>();
         message.ifPresentOrElse(
                 m -> {
-                    eventBus.sendAndForget(MessageTrackingBroadcaster.MESSAGE_SINGLE_REQUEST, m.getIdentifier());
+                    eventBus.send(MessageTrackingBroadcaster.MESSAGE_SINGLE_REQUEST, m.getIdentifier());
                     response.set(Response.ok(messageConverter.convert(m)).build());
                 },
                 () -> response.set(Response.status(Response.Status.NOT_FOUND).build()));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,6 @@ quarkus.log.category."de.dealog".level=DEBUG
 quarkus.log.console.enable=true
 quarkus.log.console.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n
 quarkus.log.console.level=DEBUG
-quarkus.log.console.color=false
 
 quarkus.log.console.json=false
 
@@ -31,14 +30,16 @@ quarkus.native.additional-build-args =-H:ReflectionConfigurationFiles=reflection
 
 user.timezone=UTC
 
-# configure kafka
-mp.messaging.incoming.messages.connector=smallrye-kafka
-mp.messaging.incoming.messages.topic=messages
-mp.messaging.incoming.messages.value.deserializer=de.dealog.common.messaging.serialization.MessageEventDeserializer
-mp.messaging.incoming.messages.auto.offset.reset=latest
+amqp-host=localhost
+amqp-port=5672
+mp.messaging.incoming.messages.connector=smallrye-amqp
+mp.messaging.incoming.messages.durable=false
 
-mp.messaging.outgoing.messages-tracking.connector=smallrye-kafka
-mp.messaging.outgoing.messages-tracking.topic=message-tracking
-mp.messaging.outgoing.messages-tracking.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
+# configure ka# configure kafkafka
+#mp.messaging.incoming.messages.auto.offset.reset=latest
+
+mp.messaging.outgoing.messages-tracking.connector=smallrye-amqp
+mp.messaging.outgoing.messages-tracking.address=messages-tracking
+mp.messaging.outgoing.messages-tracking.use-anonymous-sender=false
 
 dealog.api.version.unsupported=0.0.0


### PR DESCRIPTION
- Change reactive messaging from kafka to amqp
- Bump Quarkus from 1.13.6.Final to 2.2.2.Final